### PR TITLE
remove "standard.enable" from vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
   "git.ignoreLimitWarning": true,
   "eslint.enable": true,
   "eslint.alwaysShowStatus": true,
-  "eslint.autoFixOnSave": true,
-  "standard.enable": false
+  "eslint.autoFixOnSave": true
 }


### PR DESCRIPTION
this relies on an extension and proprietary setup that is not needed in our projects.