### PR TITLE
remove rule `react/jsx-no-target-blank` the majority are internal links

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,6 @@ module.exports = {
         'react/jsx-equals-spacing': 'error',
         'react/jsx-filename-extension': 'error',
         'react/jsx-no-duplicate-props': 'error',
-        'react/jsx-no-target-blank': 'error',
         'react/jsx-no-undef': 'error',
         'react/jsx-pascal-case': 'error',
         'react/jsx-uses-react': 'error',


### PR DESCRIPTION
As stated in [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md)

>If you do not have any external links, you can disable this rule

This rule has become more of a burden than helpful - and we're losing link attribution to our own sites.