### PR TITLE
blankline after multiline expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,8 @@ module.exports = {
               'export',
               'cjs-export',
               'import',
-              'cjs-import'
+              'cjs-import',
+              'multiline-expression'
             ],
             'next': '*'
           },


### PR DESCRIPTION
examples of what this fixes:

![image](https://user-images.githubusercontent.com/14625260/59631767-a41a3600-9116-11e9-9535-b72fd14a28f9.png)

![image](https://user-images.githubusercontent.com/14625260/59631618-45ed5300-9116-11e9-9199-401bbcee6142.png)

![image](https://user-images.githubusercontent.com/14625260/59631652-57cef600-9116-11e9-8e6b-04da60d3a5dc.png)
