### PR TITLE
fix(meta): add package deprecation & rename warning for eslint-plugin-cypress-dev

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "env": {
     "commonjs": true
-  }
+  },
+  "parserOptions": {"sourceType": "module"}
 }

--- a/deprecated.js
+++ b/deprecated.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const chalk = require('chalk').default
+const name = require('./package.json').name
+const yargs = require('yargs')
+
+const argv = yargs.string(['renamed', 'message']).argv
+
+const printNotice = ({
+  renamed,
+  message
+}) => {
+  console.log(chalk.bold(`${chalk.bgBlack('WARNING')} [${chalk.yellow(name)}]: This package is deprecated.`))
+  if (renamed) {
+    console.log(chalk.bold(`Please uninstall this package and install ${chalk.yellow(renamed)} instead: 
+    ${chalk.yellow(`
+    npm remove ${name}
+    npm i -D ${renamed}
+    `)}`))
+  }
+
+  if (message) {
+    console.log(chalk.bold(message))
+  }
+}
+
+
+printNotice({
+  renamed: argv.renamed,
+  message: argv.message
+})

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "simple-commit-message": "3.3.1"
   },
   "scripts": {
-    "postinstall": "node ./deprecated --renamed @cypress/eslint-plugin-dev --message 'you may also need to rename cypress-dev -> @cypress/dev'",
+    "postinstall": "node ./deprecated --renamed @cypress/eslint-plugin-dev --message 'you may also need to rename cypress-dev -> @cypress/dev in your .eslintrc'",
     "lint": "eslint --fix *.js",
     "precommit": "npm run lint",
     "semantic-release": "semantic-release pre && npm publish --access public && semantic-release post"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-react": "^7.2.1"
   },
   "devDependencies": {
+    "@types/yargs": "^13.0.0",
     "condition-circle": "1.5.0",
     "github-post-release": "1.13.1",
     "husky": "^0.14.3",
@@ -32,6 +33,7 @@
     "simple-commit-message": "3.3.1"
   },
   "scripts": {
+    "postinstall": "node ./deprecated --renamed @cypress/eslint-plugin-dev --message 'you may also need to rename cypress-dev -> @cypress/dev'",
     "lint": "eslint --fix *.js",
     "precommit": "npm run lint",
     "semantic-release": "semantic-release pre && npm publish --access public && semantic-release post"
@@ -40,5 +42,9 @@
     "verifyConditions": "condition-circle",
     "analyzeCommits": "simple-commit-message",
     "generateNotes": "github-post-release"
+  },
+  "dependencies": {
+    "chalk": "^2.4.2",
+    "yargs": "^13.2.4"
   }
 }


### PR DESCRIPTION
deprecate old package name and print a message to the user on postinstall
![image](https://user-images.githubusercontent.com/14625260/60390298-71225b80-9aa1-11e9-9579-d2ac92987e5d.png)
