### PR TITLE
 feat(custom-rule-feat): Allow skip-comment to accept configurable comment tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ Stop your `package.json` from being formatted:
 ```
 
 ### Custom Rules:
-name | description
--|-
+name | description | options
+-|-|-
 `@cypress/dev/arrow-body-multiline-braces` | Enforces braces in arrow functions ONLY IN multiline function definitions
-`@cypress/dev/skip-comment` | Enforces a comment (`// NOTE:`) explaining a `.skip` added to `it`, `describe`, or `context` test blocks 
+`@cypress/dev/skip-comment` | Enforces a comment (`// NOTE:`) explaining a `.skip` added to `it`, `describe`, or `context` test blocks | { commentTokens: `[array] tokens that indicate .skip explanation (default: ['NOTE:', 'TODO:', 'FIXME:']`)}
 
 ## <a name="editors"></a>Editors
 

--- a/custom-rules/skip-comment.js
+++ b/custom-rules/skip-comment.js
@@ -1,4 +1,4 @@
-const commentTokens = ['NOTE:', 'TODO:']
+const defaultCommentTokens = ['NOTE:', 'TODO:', 'FIXME:']
 
 module.exports = {
   meta: {
@@ -11,20 +11,39 @@ module.exports = {
       noOnly: `\
 Found a {{test-scope}}.skip(⋯) without an explanation.
 Add a comment above the '{{test-scope}}' starting with one of:
-${commentTokens.join('  ')}
+{{commentTokens}}
 
 e.g.
-// TODO: <reason test was skipped>
+// {{exampleCommentToken}} <reason test was skipped>
 {{test-scope}}.skip(⋯)
 
 `,
     },
 
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          commentTokens: {
+            type: 'array',
+            default: defaultCommentTokens,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     // uncomment to enable autoFix
     // fixable: 'code',
+
   },
 
   create (context) {
+
+    let commentTokens = defaultCommentTokens
+
+    if (context.options.length) {
+      commentTokens = typeof context.options[0].commentTokens === 'object' ? context.options[0].commentTokens : commentTokens
+    }
 
     const sourceCode = context.getSourceCode()
 
@@ -51,6 +70,8 @@ e.g.
               messageId: 'noOnly',
               data: {
                 'test-scope': callee.object.name,
+                commentTokens: commentTokens.join('  '),
+                exampleCommentToken: commentTokens[0],
               },
               // uncomment to enable autoFix
               // fix(fixer) {

--- a/test/fixtures/skip-comment-config.js
+++ b/test/fixtures/skip-comment-config.js
@@ -1,0 +1,10 @@
+// FOOBAR: im skipping this for good reason
+it.skip('some test', ()=>{
+
+})
+
+// NOTE: im skipping this for good reason
+it.skip('some test', ()=>{
+
+})
+

--- a/test/skip-comment.spec.js
+++ b/test/skip-comment.spec.js
@@ -67,4 +67,29 @@ describe('skip-comment', () => {
     expect(result.output).not.toBeTruthy()
   })
 
+  describe('config', () => {
+    it('skip test without comment', async () => {
+      const filename = './fixtures/skip-comment-config.js'
+      const result = execute(filename, {
+        fix: true,
+        rules: {
+          [`${pluginName}/${ruleName}`]: [
+            'error', {
+              commentTokens: ['FOOBAR:'],
+            },
+          ],
+        },
+      })
+
+      expect(result.errorCount).toBe(1)
+      // console.log(result.messages[0].message)
+
+      expect(result.messages[0].message).toContain('it')
+      expect(result.messages[0].message).toContain('FOOBAR:')
+
+      expect(result.output).not.toBeTruthy()
+    })
+
+  })
+
 })


### PR DESCRIPTION
fix #19 
- [x] allow configuration
- [x] add 'FIXME:' to defaults

### docs
- [x] document configuration options, add examples to rules