### PR TITLE
fix(custom-rules): skip-comments allow "#" before comment for coffeescript

### DIFF
--- a/custom-rules/skip-comment.js
+++ b/custom-rules/skip-comment.js
@@ -55,7 +55,7 @@ e.g.
         const commentBefore = sourceCode.getCommentsBefore(node)
 
         const hasExplain = commentBefore && commentBefore.map(
-          (v) => commentTokens.map((commentToken) => v.value.trim().startsWith(commentToken)).filter(Boolean)[0]
+          (v) => commentTokens.concat(commentTokens.map((v) => `# ${v}`)).map((commentToken) => v.value.trim().startsWith(commentToken)).filter(Boolean)[0]
         ).filter(Boolean)[0]
 
         if (hasExplain) {

--- a/test/fixtures/skip-comment-pass.js
+++ b/test/fixtures/skip-comment-pass.js
@@ -19,3 +19,7 @@ context.skip('some test', ()=>{
 it.skip('some test', ()=>{
 
 })
+//# TODO: im skipping this for good reason
+it.skip('some test', ()=>{
+
+})


### PR DESCRIPTION
- all `## TODO:` comments in coffeescript for skip explanation.