### PR TITLE
feat(rules): add padded-blocks rule, fix typescript rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -259,12 +259,16 @@ module.exports = {
           ],
           rules: {
             'no-unused-vars': 'off',
-            '@typescript-eslint/no-unused-vars': 'error',
-            'no-useless-constructor': 'off',
+            '@typescript-eslint/no-unused-vars': [
+              'error',
+              {
+                'args': 'none',
+              },
+            ],
+            '@typescript-eslint/type-annotation-spacing': 'error',
             '@typescript-eslint/no-useless-constructor': [
               'error',
             ],
-            'semi': 'off',
             '@typescript-eslint/semi': [
               'error',
               'never',

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,7 @@ const baseRules = {
     'error',
     'never',
   ],
+  'padded-blocks': ['error', 'never'],
   'padding-line-between-statements': [
     'error',
     {

--- a/lib/index.js
+++ b/lib/index.js
@@ -269,10 +269,6 @@ module.exports = {
             '@typescript-eslint/no-useless-constructor': [
               'error',
             ],
-            '@typescript-eslint/semi': [
-              'error',
-              'never',
-            ],
             '@typescript-eslint/member-delimiter-style': [
               'error',
               {


### PR DESCRIPTION
- [x] padded-blocks: cleans up whitespace before/after closing/opening braces

- [x] fix typescript-eslint rules
 - match unused-args rule with js
 - fix indent, semi errors 

BREAKING CHANGE: added padded-blocks rule which will error and auto-fix more whitespace
  inconsistencies


example of error:
```js
function () {

  const foo = 'bar'

}
```

autofixes to:
```js
function () {
  const foo = 'bar
}
```